### PR TITLE
Added the ability to show all key labels, not just C

### DIFF
--- a/static/js/st/components/keyboard.jsx
+++ b/static/js/st/components/keyboard.jsx
@@ -2,8 +2,8 @@
 import * as React from "react"
 import classNames from "classnames"
 
-import {parseNote, noteName, LETTER_OFFSETS} from "st/music"
-import {keyCodeToChar, noteForKey} from "st/keyboard_input"
+import { parseNote, noteName, LETTER_OFFSETS } from "st/music"
+import { keyCodeToChar, noteForKey } from "st/keyboard_input"
 import * as types from "prop-types"
 
 export default class Keyboard extends React.PureComponent {
@@ -24,6 +24,7 @@ export default class Keyboard extends React.PureComponent {
     }
     this.heldKeyboardKeys = {}
     this.activeTouches = {}
+    this.showKeyLabels = true
 
     this.onMouseDown = this.onMouseDown.bind(this)
     this.onTouchStart = this.onTouchStart.bind(this)
@@ -172,7 +173,7 @@ export default class Keyboard extends React.PureComponent {
 
 
       let classes = classNames("key", {
-        labeled: this.isC(pitch),
+        labeled: this.isC(pitch) || this.props.showKeyLabels,
         white: !black,
         black: black,
         held: this.props.heldNotes && this.props.heldNotes[name],

--- a/static/js/st/components/keyboard.jsx
+++ b/static/js/st/components/keyboard.jsx
@@ -2,8 +2,8 @@
 import * as React from "react"
 import classNames from "classnames"
 
-import { parseNote, noteName, LETTER_OFFSETS } from "st/music"
-import { keyCodeToChar, noteForKey } from "st/keyboard_input"
+import {parseNote, noteName, LETTER_OFFSETS} from "st/music"
+import {keyCodeToChar, noteForKey} from "st/keyboard_input"
 import * as types from "prop-types"
 
 export default class Keyboard extends React.PureComponent {
@@ -24,7 +24,6 @@ export default class Keyboard extends React.PureComponent {
     }
     this.heldKeyboardKeys = {}
     this.activeTouches = {}
-    this.showKeyLabels = true
 
     this.onMouseDown = this.onMouseDown.bind(this)
     this.onTouchStart = this.onTouchStart.bind(this)

--- a/static/js/st/components/pages/sight_reading_page.jsx
+++ b/static/js/st/components/pages/sight_reading_page.jsx
@@ -52,6 +52,7 @@ export default class SightReadingPage extends React.Component {
 
       bufferSize: 10,
       keyboardOpen: true,
+      showKeyLabels: false,
       settingsOpen: false,
       scale: window.innerWidth < 1000 ? 0.8 : 1,
       stats: new NoteStats(session.currentUser),
@@ -424,7 +425,12 @@ export default class SightReadingPage extends React.Component {
   }
 
   toggleKeyboard() {
-    this.setState({keyboardOpen: !this.state.keyboardOpen});
+    this.setState({ keyboardOpen: !this.state.keyboardOpen });
+    this.recalcFlex();
+  }
+
+  toggleKeyLabels() {
+    this.setState({ showKeyLabels: !this.state.showKeyLabels });
     this.recalcFlex();
   }
 
@@ -458,6 +464,7 @@ export default class SightReadingPage extends React.Component {
         {this.renderSettings()}
       </TransitionGroup>
 
+      {this.state.keyboardOpen && this.renderKeylabelToggle()}
       {this.renderKeyboardToggle()}
     </div>;
   }
@@ -470,6 +477,17 @@ export default class SightReadingPage extends React.Component {
       onClick={this.toggleKeyboard.bind(this)}
       className="keyboard_toggle">
       {this.state.keyboardOpen ? "Hide Keyboard" : "Show Keyboard"}
+    </button>
+  }
+
+  renderKeylabelToggle() {
+    if (!this.state.currentStaff) { return }
+    if (this.state.currentStaff.mode != "notes") { return }
+
+    return <button
+      onClick={this.toggleKeyLabels.bind(this)}
+      className="keyboardlabel_toggle">
+      {this.state.showKeyLabels ? "Hide Key Label" : "Show Key Label"}
     </button>
   }
 
@@ -513,6 +531,7 @@ export default class SightReadingPage extends React.Component {
       upper={upper}
       midiOutput={this.props.midiOutput}
       heldNotes={this.state.heldNotes}
+      showKeyLabels={this.state.showKeyLabels}
       onKeyDown={this.pressNote}
       onKeyUp={this.releaseNote} />;
   }

--- a/static/scss/sight_reading_page.scss
+++ b/static/scss/sight_reading_page.scss
@@ -13,6 +13,11 @@
         .workspace_header, .keyboard_toggle, .toolbar {
             display: none;
         }
+
+        .workspace_header, .keyboardlabel_toggle, .toolbar {
+            display: none;
+        }
+
     }
 
     .workspace_header{
@@ -151,6 +156,13 @@
         position: absolute;
         z-index: 2;
         bottom: 10px;
+        right: 10px;
+    }
+
+    .keyboardlabel_toggle {
+        position: absolute;
+        z-index: 2;
+        bottom: 40px;
         right: 10px;
     }
 }


### PR DESCRIPTION
Hello, 

I added an additional button above the "Hide Keyboard" that turns on the label rendering on all the keys, not just C. I wanted to know this information during my learning, so I better remember where each key is 